### PR TITLE
Solving install problems with 'Undeclared variable sql'

### DIFF
--- a/app/code/community/Rakuten/RakutenPay/sql/rakuten_rakutenpay_setup/mysql4-install-1.0.0.php
+++ b/app/code/community/Rakuten/RakutenPay/sql/rakuten_rakutenpay_setup/mysql4-install-1.0.0.php
@@ -25,7 +25,7 @@ $tp = (string)Mage::getConfig()->getTablePrefix();
 $table = $tp . "sales_order_status";
 
 // Verifies that no record of the status RakutenPay created, if you have not created
-$sql .= "INSERT INTO `" . $table . "` (STATUS, label)
+$sql = "INSERT INTO `" . $table . "` (STATUS, label)
          SELECT p.status, p.label FROM(SELECT 'aguardando_pagamento_rp' AS STATUS, 'Aguardando Pagamento' AS label) p
          WHERE (SELECT COUNT(STATUS) FROM `" . $table . "` WHERE STATUS = 'aguardando_pagamento_rp') = 0;
 

--- a/app/code/community/Rakuten/RakutenPay/sql/rakuten_rakutenpay_setup/mysql4-install-1.0.1.php
+++ b/app/code/community/Rakuten/RakutenPay/sql/rakuten_rakutenpay_setup/mysql4-install-1.0.1.php
@@ -25,7 +25,7 @@ $tp = (string)Mage::getConfig()->getTablePrefix();
 $table = $tp . "sales_order_status";
 
 // Verifies that no record of the status RakutenPay created, if you have not created
-$sql .= "INSERT INTO `" . $table . "` (STATUS, label)
+$sql = "INSERT INTO `" . $table . "` (STATUS, label)
          SELECT p.status, p.label FROM(SELECT 'aguardando_pagamento_rp' AS STATUS, 'Aguardando Pagamento' AS label) p
          WHERE (SELECT COUNT(STATUS) FROM `" . $table . "` WHERE STATUS = 'aguardando_pagamento_rp') = 0;
 


### PR DESCRIPTION
When installing the module and PHP error reporting all, it was reporting; Error in file: "Notice: Undefined variable: sql  in app/code/community/Rakuten/RakutenPay/sql/rakuten_rakutenpay_setup/mysql4-install-1.0.1.php on line 54"