### PR TITLE
[Pay][Connector] Observer fica inativo quando pula a etapa de preenchimento dos dados Cadastrais

### DIFF
--- a/skin/frontend/base/default/rakuten/rakutenpay/js/rakutenpay-onestepcheckout-before-save.js
+++ b/skin/frontend/base/default/rakuten/rakutenpay/js/rakutenpay-onestepcheckout-before-save.js
@@ -179,6 +179,19 @@ OnestepcheckoutShipment.prototype.switchToMethod = OnestepcheckoutShipment.proto
     });
 
 OnestepcheckoutForm.prototype.validate = OnestepcheckoutForm.prototype.validate.wrap(function (validate) {
+
+    var paymentMethod = document.querySelector('#checkout-payment-method-load .radio:checked').value;
+
+    if (paymentMethod === "rakutenpay_credit_card") {
+        var creditCardNum = document.querySelector('#creditCardNumVisible');
+        var creditCardMonth = document.querySelector('#creditCardExpirationMonth');
+        var creditCardYear = document.querySelector('#creditCardExpirationYear');
+
+        updateCreditCardToken(creditCardNum.value, creditCardMonth.value, creditCardYear.value);
+    } else if (paymentMethod === "rakutenpay_boleto") {
+        updateBilletFingerprint();
+    }
+
     return validate() && validateRakutenPayActiveMethod();
 });
 


### PR DESCRIPTION
# Proposta

**Jira Card:** [[Pay][Connector] Observer fica inativo quando pula a etapa de preenchimento dos dados Cadastrais](https://rakutenbrazil.atlassian.net/browse/CON-197)

Este PR Ajusta o Observer no OSC.
 
# Tarefas Realizadas

- [X] Inserido campos para fingerprint e token na Validação do OSC.