### PR TITLE
[Pay] Estourando Erro PHP quando o payload estiver false e não tem retorno da API

### DIFF
--- a/app/code/community/Rakuten/RakutenPay/controllers/PaymentController.php
+++ b/app/code/community/Rakuten/RakutenPay/controllers/PaymentController.php
@@ -214,15 +214,16 @@ class Rakuten_RakutenPay_PaymentController extends Mage_Core_Controller_Front_Ac
             }
 
             if ($result === false || $result->getResult() == \Rakuten\Connector\Enum\DirectPayment\Message::FAILURE) {
-                \Rakuten\Connector\Resources\Log\Logger::error('Result is failure...');
+                $message = method_exists($result,'getResultMessage') ? $result->getResultMessage() : 'Result is failure...';
                 $this->canceledStatus(
                     $order,
                     false,
                     '',
                     false,
-                    $result->getResultMessage()
+                    $message
                 );
-                throw new \Rakuten\Connector\Exception\ConnectorException($result->getResultMessage());
+                \Rakuten\Connector\Resources\Log\Logger::error($message);
+                throw new \Rakuten\Connector\Exception\ConnectorException($message);
             }
 
             if ($result->getResult() == \Rakuten\Connector\Enum\DirectPayment\Message::DECLINED ||

--- a/app/code/community/Rakuten/RakutenPay/etc/config.xml
+++ b/app/code/community/Rakuten/RakutenPay/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Rakuten_RakutenPay>
-            <version>1.3.6</version>
+            <version>1.3.7</version>
         </Rakuten_RakutenPay>
     </modules>
     <global>

--- a/lib/Rakuten/Connector/src/Enum/Http/Status.php
+++ b/lib/Rakuten/Connector/src/Enum/Http/Status.php
@@ -59,8 +59,4 @@ class Status extends Enum
      * Http Method 502 - Bad gateway.
      */
     const BAD_GATEWAY = 502;
-    /**
-     * Http Method 4xx - Client Errors.
-     */
-    const CLIENT_ERRORS = 4;
 }

--- a/lib/Rakuten/Connector/src/Resources/Responsibility.php
+++ b/lib/Rakuten/Connector/src/Resources/Responsibility.php
@@ -34,15 +34,24 @@ class Responsibility
 {
     public static function http($http, $class)
     {
-        $firstDigit = substr($http->getStatus(), 0, 1);
-        switch (true) {
-            case ($http->getStatus() == Status::OK):
+        switch ($http->getStatus()) {
+            case Status::OK:
                 return $class::success($http);
-            case ($http->getStatus() == Status::BAD_GATEWAY):
+            case Status::UNPROCESSABLE:
+                /** returns success because only a few parameters  */
+                return $class::success($http);
+            case Status::BAD_REQUEST:
+                /** returns success because only a few parameters  */
+                return $class::success($http);
+            case Status::NOT_FOUND:
                 $error = $class::error($http);
                 throw new ConnectorException($error->getMessage(), $error->getCode());
-            case ($firstDigit == Status::CLIENT_ERRORS):
-                return $class::success($http);
+            case Status::UNAUTHORIZED:
+                $error = $class::error($http);
+                throw new ConnectorException($error->getMessage(), $error->getCode());
+            case Status::BAD_GATEWAY:
+                $error = $class::error($http);
+                throw new ConnectorException($error->getMessage(), $error->getCode());
             default:
                 unset($class);
                 throw new ConnectorException($http->getResponse(), $http->getStatus());


### PR DESCRIPTION
# Propósito

**Jira Card:** [[Pay] Estourando Erro PHP quando o payload estiver false e não tem retorno da API](https://rakutenbrazil.atlassian.net/browse/CON-326)

Este PR Faz Adiciona novos status code HTTP e pontos de exceções.
 
# Tarefas Realizadas

- [X] Alterado o `Responsibility` para verificar novos Status HTTP retirado a verificação genérica do Client Errors.
- [X] Feito a correção para quando o Payload não existir no retorno do Response afim de `Cancelar` automaticamente o pedido.