### PR TITLE
[Pay] Erro nos Status utilizando a Cron no Magento 1 reportado pela Cristo Rei

### DIFF
--- a/app/code/community/Rakuten/RakutenPay/Block/Info/Boleto.php
+++ b/app/code/community/Rakuten/RakutenPay/Block/Info/Boleto.php
@@ -84,10 +84,11 @@ class Rakuten_RakutenPay_Block_Info_Boleto extends Mage_Payment_Block_Info
 
     public function getDashboardLink()
     {
+        $environment = Mage::getStoreConfig('payment/rakutenpay/environment');
         if (empty($this->getInfo())) {
             return null;
         }
 
-        return self::DASHBOARD_LINK . $this->getInfo()->getAdditionalInformation('rakutenpay_id');
+        return \Rakuten\Connector\Enum\DirectPayment\Link::getDashboardLink($environment) . $this->getInfo()->getAdditionalInformation('rakutenpay_id');
     }
 }

--- a/app/code/community/Rakuten/RakutenPay/Block/Info/Boleto.php
+++ b/app/code/community/Rakuten/RakutenPay/Block/Info/Boleto.php
@@ -22,7 +22,6 @@
  */
 class Rakuten_RakutenPay_Block_Info_Boleto extends Mage_Payment_Block_Info
 {
-    const DASHBOARD_LINK = 'https://dashboard.rakutenpay.com.br/sales/';
 
     protected function _construct()
     {

--- a/app/code/community/Rakuten/RakutenPay/Block/Info/Boleto.php
+++ b/app/code/community/Rakuten/RakutenPay/Block/Info/Boleto.php
@@ -22,6 +22,8 @@
  */
 class Rakuten_RakutenPay_Block_Info_Boleto extends Mage_Payment_Block_Info
 {
+    const DASHBOARD_LINK = 'https://dashboard.rakutenpay.com.br/sales/';
+
     protected function _construct()
     {
         parent::_construct();
@@ -78,5 +80,14 @@ class Rakuten_RakutenPay_Block_Info_Boleto extends Mage_Payment_Block_Info
         }
 
         return $this->getInfo()->getAdditionalInformation('tracking_url');
+    }
+
+    public function getDashboardLink()
+    {
+        if (empty($this->getInfo())) {
+            return null;
+        }
+
+        return self::DASHBOARD_LINK . $this->getInfo()->getAdditionalInformation('rakutenpay_id');
     }
 }

--- a/app/code/community/Rakuten/RakutenPay/Block/Info/CreditCard.php
+++ b/app/code/community/Rakuten/RakutenPay/Block/Info/CreditCard.php
@@ -100,10 +100,11 @@ class Rakuten_RakutenPay_Block_Info_CreditCard extends Mage_Payment_Block_Info
 
     public function getDashboardLink()
     {
+        $environment = Mage::getStoreConfig('payment/rakutenpay/environment');
         if (empty($this->getInfo())) {
             return null;
         }
 
-        return self::DASHBOARD_LINK . $this->getInfo()->getAdditionalInformation('rakutenpay_id');
+        return \Rakuten\Connector\Enum\DirectPayment\Link::getDashboardLink($environment) . $this->getInfo()->getAdditionalInformation('rakutenpay_id');
     }
 }

--- a/app/code/community/Rakuten/RakutenPay/Block/Info/CreditCard.php
+++ b/app/code/community/Rakuten/RakutenPay/Block/Info/CreditCard.php
@@ -24,6 +24,8 @@
  */
 class Rakuten_RakutenPay_Block_Info_CreditCard extends Mage_Payment_Block_Info
 {
+    const DASHBOARD_LINK = 'https://dashboard.rakutenpay.com.br/sales/';
+
     protected function _construct()
     {
         parent::_construct();
@@ -94,5 +96,14 @@ class Rakuten_RakutenPay_Block_Info_CreditCard extends Mage_Payment_Block_Info
         }
 
         return $this->getInfo()->getAdditionalInformation('tracking_url');
+    }
+
+    public function getDashboardLink()
+    {
+        if (empty($this->getInfo())) {
+            return null;
+        }
+
+        return self::DASHBOARD_LINK . $this->getInfo()->getAdditionalInformation('rakutenpay_id');
     }
 }

--- a/app/code/community/Rakuten/RakutenPay/Block/Info/CreditCard.php
+++ b/app/code/community/Rakuten/RakutenPay/Block/Info/CreditCard.php
@@ -24,7 +24,6 @@
  */
 class Rakuten_RakutenPay_Block_Info_CreditCard extends Mage_Payment_Block_Info
 {
-    const DASHBOARD_LINK = 'https://dashboard.rakutenpay.com.br/sales/';
 
     protected function _construct()
     {

--- a/app/code/community/Rakuten/RakutenPay/Helper/Log.php
+++ b/app/code/community/Rakuten/RakutenPay/Helper/Log.php
@@ -23,37 +23,6 @@
 class Rakuten_RakutenPay_Helper_Log
 {
     /**
-     * @param $orderId
-     * @param $recoveryCode
-     */
-    public function setAbandonedSendEmailLog($orderId, $recoveryCode)
-    {
-        $module = 'RakutenPayAbandoned.';
-        $phrase = "Mail( SendEmailAbandoned: array (\n 'orderId' => ".$orderId.",\n ";
-        $phrase .= "'recoveryCode' => '".$recoveryCode."'\n) )";
-        \Rakuten\Connector\Resources\Log\Logger::info($phrase, ['service' => $module]);
-    }
-
-    /**
-     * @param $orderId
-     * @param $sent
-     */
-    public function setAbandonedSentEmailUpdateLog($orderId, $sent)
-    {
-        $module = 'RakutenPayAbandoned.';
-        $phrase = "SentEmailUpdate( Has been updated to ".$sent." the number of emails sent,";
-        $phrase .= " belonging to order ".$orderId." )";
-        \Rakuten\Connector\Resources\Log\Logger::info($phrase, ['service' => $module]);
-    }
-
-    public function setRequirementsLog()
-    {
-        $module = 'RakutenPayRequirements.';
-        $phrase = "Verification ( Checked requirements )";
-        \Rakuten\Connector\Resources\Log\Logger::info($phrase, ['service' => $module]);
-    }
-
-    /**
      * @param $class
      *
      * @return null|string

--- a/app/code/community/Rakuten/RakutenPay/Model/NotificationMethod.php
+++ b/app/code/community/Rakuten/RakutenPay/Model/NotificationMethod.php
@@ -52,11 +52,11 @@ class Rakuten_RakutenPay_Model_NotificationMethod extends MethodAbstract
         $this->webhookStatus = $this->post['status'];
         $this->webhookReference = $this->post['reference'];
         if ($this->webhookStatus == 'approved') {
-            $this->amount = $this->post['amount'];
+            $this->amount = (float) $this->post['amount'];
         } else if (
             $this->webhookStatus == \Rakuten\Connector\Enum\DirectPayment\State::PARTIAL_REFUNDED ||
             $this->webhookStatus == \Rakuten\Connector\Enum\DirectPayment\State::REFUNDED) {
-            $this->amount = -array_sum(array_column($this->post['refunds'], 'amount'));
+            $this->amount = (float) -array_sum(array_column($this->post['refunds'], 'amount'));
         } else {
             $this->amount = false;
         }

--- a/app/code/community/Rakuten/RakutenPay/Model/PaymentMethod.php
+++ b/app/code/community/Rakuten/RakutenPay/Model/PaymentMethod.php
@@ -62,6 +62,7 @@ class Rakuten_RakutenPay_Model_PaymentMethod extends Mage_Payment_Model_Method_A
 
     /**
      * @param Mage_Sales_Model_Order $order
+     * @param $chargeId
      * @throws Exception
      */
     public function addRakutenPayOrders(Mage_Sales_Model_Order $order)
@@ -80,6 +81,7 @@ class Rakuten_RakutenPay_Model_PaymentMethod extends Mage_Payment_Model_Method_A
         $rakutenOrder->setOrderId($order->getId());
         $rakutenOrder->setCalculationCode($calculationCode);
         $rakutenOrder->setEnvironment($environment);
+        $rakutenOrder->setIncrementId($order->getIncrementId());
         $rakutenOrder->save();
     }
 

--- a/app/code/community/Rakuten/RakutenPay/controllers/PaymentController.php
+++ b/app/code/community/Rakuten/RakutenPay/controllers/PaymentController.php
@@ -181,6 +181,7 @@ class Rakuten_RakutenPay_PaymentController extends Mage_Core_Controller_Front_Ac
         $result         = null;
         $redirect       = 'rakutenpay/payment/success';
         $redirectParams = array();
+        $helper         = Mage::helper('rakutenpay');
 
         try {
             \Rakuten\Connector\Resources\Log\Logger::info('Processing directAction in PaymentController.');
@@ -250,7 +251,10 @@ class Rakuten_RakutenPay_PaymentController extends Mage_Core_Controller_Front_Ac
                     $result->getResultMessage()
                 );
             }
-
+            \Rakuten\Connector\Resources\Log\Logger::info('Setting orderStatus in setTransactionRecord.');
+            $helper->setTransactionRecord($order->getId(), $result->getOrderStatus(), $result->getId(), $order->getIncrementId());
+            \Rakuten\Connector\Resources\Log\Logger::info('Got the payment data.');
+            $this->payment->addRakutenPayOrders($order);
             /** controy redirect url according with payment return link **/
             if (method_exists($result, 'getBillet') && $result->getBillet()) {
                 $billetUrl = $result->getBilletUrl();

--- a/app/code/community/Rakuten/RakutenPay/etc/config.xml
+++ b/app/code/community/Rakuten/RakutenPay/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Rakuten_RakutenPay>
-            <version>1.4.2</version>
+            <version>1.5.0</version>
         </Rakuten_RakutenPay>
     </modules>
     <global>
@@ -216,12 +216,13 @@
     <default>
         <cron>
             <update_order_state>
-                <active>0</active>
+                <active>1</active>
+                <days>30</days>
             </update_order_state>
         </cron>
         <log>
             <file_write>
-                <active>0</active>
+                <active>1</active>
             </file_write>
             <configuration>
                 <active>0</active>

--- a/app/code/community/Rakuten/RakutenPay/etc/config.xml
+++ b/app/code/community/Rakuten/RakutenPay/etc/config.xml
@@ -216,13 +216,13 @@
     <default>
         <cron>
             <update_order_state>
-                <active>1</active>
+                <active>0</active>
                 <days>30</days>
             </update_order_state>
         </cron>
         <log>
             <file_write>
-                <active>1</active>
+                <active>0</active>
             </file_write>
             <configuration>
                 <active>0</active>

--- a/app/code/community/Rakuten/RakutenPay/sql/rakuten_rakutenpay_setup/mysql4-install-1.0.0.php
+++ b/app/code/community/Rakuten/RakutenPay/sql/rakuten_rakutenpay_setup/mysql4-install-1.0.0.php
@@ -29,8 +29,9 @@ $newTable =  $tp . 'rakutenpay_orders';
 $sql = "CREATE TABLE IF NOT EXISTS `" . $newTable . "` (
          `entity_id` int(11) NOT NULL AUTO_INCREMENT,
          `order_id` int(11),
+         `increment_id` varchar(80),
+         `charge_uuid` varchar(80),
          `transaction_code` varchar(80) NOT NULL,
-         `sent` int DEFAULT 0,
          `environment` varchar(40),
          `batch_label_url` TEXT DEFAULT NULL,
          `calculation_code` TEXT DEFAULT NULL,

--- a/app/design/adminhtml/default/default/template/rakuten/rakutenpay/info/boleto.phtml
+++ b/app/design/adminhtml/default/default/template/rakuten/rakutenpay/info/boleto.phtml
@@ -68,7 +68,9 @@
     </p>
     <p><span id="link-message"></span></p>
 <?php } ?>
-
+<?php if(!empty($this->getDashboardLink())): ?>
+    <p><button class="button" onclick="window.location.href='<?php echo $this->getDashboardLink(); ?>'">Dashboard RakutenPay</button><br></p>
+<?php endif;?>
 <?php if(!empty($this->getLabelUrl()) && !empty($this->getTrackingUrl())) { ?>
 <br><p><b>Rakuten Logistics</b></p>
 <p>

--- a/app/design/adminhtml/default/default/template/rakuten/rakutenpay/info/credit_card.phtml
+++ b/app/design/adminhtml/default/default/template/rakuten/rakutenpay/info/credit_card.phtml
@@ -35,6 +35,9 @@
 <?php if(!empty($this->getApprovedDate())): ?>
     <span><strong>Data da Aprovação: </strong><?php echo $this->getApprovedDate(); ?></span><br>
 <?php endif;?>
+<?php if(!empty($this->getDashboardLink())): ?>
+    <p><button class="button" onclick="window.location.href='<?php echo $this->getDashboardLink(); ?>'">Dashboard RakutenPay</button><br></p>
+<?php endif;?>
 <?php if(!empty($this->getLabelUrl()) && !empty($this->getTrackingUrl())): ?>
     <br><p><b>Rakuten Logistics</b></p>
     <p>

--- a/lib/Rakuten/Connector/src/Enum/DirectPayment/Link.php
+++ b/lib/Rakuten/Connector/src/Enum/DirectPayment/Link.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rakuten\Connector\Enum\DirectPayment;
+
+/**
+ * Class Link
+ * @package Rakuten\Connector\Enum\DirectPayment
+ */
+class Link
+{
+    const DASHBOARD_LINK_PRODUCTION = 'https://dashboard.rakutenpay.com.br/sales/';
+    const DASHBOARD_LINK_SANDBOX = 'https://dashboard-sandbox.rakutenpay.com.br/sales/';
+
+    const SANDBOX = 'sandbox';
+    const PRODUCTION = 'production';
+
+    /**
+     * @var array
+     */
+    private static $mappingLink = [
+        self::SANDBOX => self::DASHBOARD_LINK_SANDBOX,
+        self::PRODUCTION => self::DASHBOARD_LINK_PRODUCTION,
+    ];
+
+    /**
+     * @param $environment
+     * @return bool|string
+     */
+    public static function getDashboardLink($environment)
+    {
+        return isset(self::$mappingLink[$environment]) ? self::$mappingLink[$environment] : false;
+    }
+}

--- a/lib/Rakuten/Connector/src/Parsers/DirectPayment/Boleto/Request.php
+++ b/lib/Rakuten/Connector/src/Parsers/DirectPayment/Boleto/Request.php
@@ -76,6 +76,7 @@ class Request extends Error implements Parser
         return $response->setResult($data['result'])
             ->setId($data['charge_uuid'])
             ->setCharge($chargeUrl)
+            ->setOrderStatus($payment['status'])
             ->setBillet($payment['billet']['download_url'])
             ->setBilletUrl($payment['billet']['url'])
             ->setResultMessage(implode(' - ', $data['result_messages']));

--- a/lib/Rakuten/Connector/src/Parsers/DirectPayment/CreditCard/Request.php
+++ b/lib/Rakuten/Connector/src/Parsers/DirectPayment/CreditCard/Request.php
@@ -76,6 +76,7 @@ class Request extends Error implements Parser
         return $response->setResult($data['result'])
             ->setId($data['charge_uuid'])
             ->setCharge($chargeUrl)
+            ->setOrderStatus($payment['status'])
             ->setCreditCardNum($payment['credit_card']['number'])
             ->setResultMessage(implode(' - ', $payment['result_messages']));
     }

--- a/lib/Rakuten/Connector/src/Parsers/Transaction/Boleto/Response.php
+++ b/lib/Rakuten/Connector/src/Parsers/Transaction/Boleto/Response.php
@@ -31,6 +31,8 @@ class Response extends \Rakuten\Connector\Parsers\Transaction\Response
 
     private $charge;
 
+    private $orderStatus;
+
     private $billet;
 
     private $billetUrl;
@@ -49,6 +51,10 @@ class Response extends \Rakuten\Connector\Parsers\Transaction\Response
 
     function getCharge() {
         return $this->charge;
+    }
+
+    function getOrderStatus() {
+        return $this->orderStatus;
     }
 
     function getBillet() {
@@ -79,6 +85,11 @@ class Response extends \Rakuten\Connector\Parsers\Transaction\Response
 
     function setCharge($charge) {
         $this->charge = $charge;
+        return $this;
+    }
+
+    function setOrderStatus($orderStatus) {
+        $this->orderStatus = $orderStatus;
         return $this;
     }
 

--- a/lib/Rakuten/Connector/src/Parsers/Transaction/CreditCard/Response.php
+++ b/lib/Rakuten/Connector/src/Parsers/Transaction/CreditCard/Response.php
@@ -31,6 +31,8 @@ class Response extends \Rakuten\Connector\Parsers\Transaction\Response
 
     private $charge;
 
+    private $orderStatus;
+
     private $creditCardNum;
 
     private $brand;
@@ -49,6 +51,10 @@ class Response extends \Rakuten\Connector\Parsers\Transaction\Response
 
     function getCharge() {
         return $this->charge;
+    }
+
+    function getOrderStatus() {
+        return $this->orderStatus;
     }
 
     function getCreditCardNum() {
@@ -80,6 +86,11 @@ class Response extends \Rakuten\Connector\Parsers\Transaction\Response
 
     function setCharge($charge) {
         $this->charge = $charge;
+        return $this;
+    }
+
+    function setOrderStatus($orderStatus) {
+        $this->orderStatus = $orderStatus;
         return $this;
     }
 


### PR DESCRIPTION
# Propósito

**Jira Card:** [[Pay] Erro nos Status utilizando a Cron no Magento 1 reportado pela Cristo Rei](https://rakutenbrazil.atlassian.net/browse/CON-424)

Este PR Refatora a transição de Status.
 
# Tarefas Realizadas

- [X] Refatorado toda a CRON.
- [X] Adicionado flag para o search de Orders por dias.
- [X] Removido métodos que não estão funcionais no magento 1 - olhe o `@see` do código.
- [X] Refeito o `refund` e o `partial_refund`
- [X] Modificado a migration do `rakutenpay_orders` para que o plugin tenha mais controle
- [X] Segunido o padrão do Magento 2, o `partial_refund` continua em `processing` mas com comentários de refund.
- [X] Refeito o envio de email para o cliente e adicionado os comentários de `partial_refund`
- [X] Adicionado métodos para fazer a migration dos pedidos da `order` para o `rakutenpay_orders` - Só para quem usa a CRON
- [ ] `Remover métodos nos próximos releases.`